### PR TITLE
feat: add reusable workflows for consumption across repos

### DIFF
--- a/.github/workflows/check-community-approval.yaml
+++ b/.github/workflows/check-community-approval.yaml
@@ -1,9 +1,6 @@
 name: Check Community Approval
 on: workflow_call
 
-permissions:
-  contents: read
-
 jobs:
   check_community_approval:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-community-approval.yaml
+++ b/.github/workflows/check-community-approval.yaml
@@ -3,6 +3,8 @@
 
 name: check-community-approval
 on: workflow_call
+permissions:
+  contents: read
 
 jobs:
   check-community-approval:

--- a/.github/workflows/check-community-approval.yaml
+++ b/.github/workflows/check-community-approval.yaml
@@ -1,19 +1,11 @@
 name: Check Community Approval
-
-on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - labeled
-      - unlabeled
+on: workflow_call
 
 permissions:
   contents: read
 
 jobs:
-  check_approval:
+  check_community_approval:
     runs-on: ubuntu-latest
     steps:
       - name: Check for community approval

--- a/.github/workflows/check-community-approval.yaml
+++ b/.github/workflows/check-community-approval.yaml
@@ -1,3 +1,6 @@
+# Required Permissions:
+#   contents: read
+
 name: Check Community Approval
 on: workflow_call
 

--- a/.github/workflows/check-community-approval.yaml
+++ b/.github/workflows/check-community-approval.yaml
@@ -1,14 +1,15 @@
 # Required Permissions:
 #   contents: read
 
-name: Check Community Approval
+name: check-community-approval
 on: workflow_call
 
 jobs:
-  check_community_approval:
+  check-community-approval:
+    name: check-community-approval
     runs-on: ubuntu-latest
     steps:
-      - name: Check for community approval
+      - name: check-community-approval
         run: |
           if [[ "${{ contains(github.event.pull_request.labels.*.name, 'community-approved') }}" == "true" ]]; then
             echo "This PR has met the requirements for community approval."

--- a/.github/workflows/check-pr-thumbs-up.yaml
+++ b/.github/workflows/check-pr-thumbs-up.yaml
@@ -1,9 +1,6 @@
 name: Check PR Thumbs Up
 on: workflow_call
 
-permissions:
-  contents: read
-
 jobs:
   check-pr-thumbs-up:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-pr-thumbs-up.yaml
+++ b/.github/workflows/check-pr-thumbs-up.yaml
@@ -3,6 +3,8 @@
 
 name: check-pr-thumbs-up
 on: workflow_call
+permissions:
+  contents: read
 
 jobs:
   check-pr-thumbs-up:

--- a/.github/workflows/check-pr-thumbs-up.yaml
+++ b/.github/workflows/check-pr-thumbs-up.yaml
@@ -1,10 +1,5 @@
-name: Check PR Thumbs Up and Manage Labels
-
-on:
-  schedule:
-    - cron: '0 5 * * *'   # Runs daily at 10:00 PM MST (5:00 AM UTC next day)
-    - cron: '0 13 * * *'  # Runs daily at 6:00 AM MST (1:00 PM UTC)  
-    - cron: '0 19 * * *'  # Runs daily at 12:00 PM MST (7:00 PM UTC)
+name: Check PR Thumbs Up
+on: workflow_call
 
 permissions:
   contents: read

--- a/.github/workflows/check-pr-thumbs-up.yaml
+++ b/.github/workflows/check-pr-thumbs-up.yaml
@@ -1,11 +1,12 @@
 # Required Permissions:
 #   contents: read
 
-name: Check PR Thumbs Up
+name: check-pr-thumbs-up
 on: workflow_call
 
 jobs:
   check-pr-thumbs-up:
+    name: check-pr-thumbs-up
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.LABEL_PRS_TOKEN }}

--- a/.github/workflows/check-pr-thumbs-up.yaml
+++ b/.github/workflows/check-pr-thumbs-up.yaml
@@ -1,3 +1,6 @@
+# Required Permissions:
+#   contents: read
+
 name: Check PR Thumbs Up
 on: workflow_call
 

--- a/.github/workflows/ossf-scorecard.yaml
+++ b/.github/workflows/ossf-scorecard.yaml
@@ -1,3 +1,7 @@
+# Required Permissions:
+#   security-events: write
+#   id-token: write
+
 name: OSSF Scorecard
 on: workflow_call
 

--- a/.github/workflows/ossf-scorecard.yaml
+++ b/.github/workflows/ossf-scorecard.yaml
@@ -1,9 +1,5 @@
 name: OSSF Scorecard
-on:
-  schedule:
-    - cron: '0 5 * * 1' # Every Sunday at 10pm MST (5:00 UTC)
-  push:
-    branches: [ "main" ]
+on: workflow_call
 
 permissions: read-all
 

--- a/.github/workflows/ossf-scorecard.yaml
+++ b/.github/workflows/ossf-scorecard.yaml
@@ -2,12 +2,12 @@
 #   security-events: write
 #   id-token: write
 
-name: OSSF Scorecard
+name: ossf-scorecard
 on: workflow_call
 
 jobs:
-  analysis:
-    name: Scorecard analysis
+  ossf-scorecard:
+    name: ossf-scorecard
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout code"

--- a/.github/workflows/ossf-scorecard.yaml
+++ b/.github/workflows/ossf-scorecard.yaml
@@ -4,6 +4,8 @@
 
 name: ossf-scorecard
 on: workflow_call
+permissions:
+  contents: read
 
 jobs:
   ossf-scorecard:

--- a/.github/workflows/ossf-scorecard.yaml
+++ b/.github/workflows/ossf-scorecard.yaml
@@ -1,16 +1,10 @@
 name: OSSF Scorecard
 on: workflow_call
 
-permissions: read-all
-
 jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-      id-token: write
-
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v5

--- a/.github/workflows/semver-release.yaml
+++ b/.github/workflows/semver-release.yaml
@@ -1,9 +1,6 @@
 name: Semver Release
 on: workflow_call
 
-permissions:
-  contents: read
-
 jobs:
   release:
     name: Release

--- a/.github/workflows/semver-release.yaml
+++ b/.github/workflows/semver-release.yaml
@@ -1,3 +1,9 @@
+# Required Permissions:
+#   contents: write
+#   issues: write
+#   pull-requests: write
+#   id-token: write
+
 name: Semver Release
 on: workflow_call
 

--- a/.github/workflows/semver-release.yaml
+++ b/.github/workflows/semver-release.yaml
@@ -1,8 +1,5 @@
 name: Semver Release
-on:
-  push:
-    branches:
-      - main
+on: workflow_call
 
 permissions:
   contents: read

--- a/.github/workflows/semver-release.yaml
+++ b/.github/workflows/semver-release.yaml
@@ -6,6 +6,8 @@
 
 name: semver-release
 on: workflow_call
+permissions:
+  contents: read
 
 jobs:
   semver-release:

--- a/.github/workflows/semver-release.yaml
+++ b/.github/workflows/semver-release.yaml
@@ -4,20 +4,13 @@
 #   pull-requests: write
 #   id-token: write
 
-name: Semver Release
+name: semver-release
 on: workflow_call
 
 jobs:
-  release:
-    name: Release
+  semver-release:
+    name: semver-release
     runs-on: ubuntu-latest
-
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
-      id-token: write
-
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -3,6 +3,8 @@
 
 name: validate-pr-title
 on: workflow_call
+permissions:
+  contents: read
 
 jobs:
   validate-pr-title:

--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -1,12 +1,5 @@
-name: "Validate PR Title"
-
-on:
-  pull_request_target:
-    types:
-      - opened
-      - synchronize
-      - edited
-      - reopened
+name: Validate Semver PR Title
+on: workflow_call
 
 permissions:
   contents: read

--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -1,9 +1,6 @@
 name: Validate Semver PR Title
 on: workflow_call
 
-permissions:
-  contents: read
-
 jobs:
   validate_pr_title:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -1,14 +1,13 @@
 # Required Permissions:
 #   pull-requests: read
 
-name: Validate Semver PR Title
+name: validate-pr-title
 on: workflow_call
 
 jobs:
-  validate_pr_title:
+  validate-pr-title:
+    name: validate-pr-title
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         env:

--- a/.github/workflows/validate-pr-title.yaml
+++ b/.github/workflows/validate-pr-title.yaml
@@ -1,3 +1,6 @@
+# Required Permissions:
+#   pull-requests: read
+
 name: Validate Semver PR Title
 on: workflow_call
 

--- a/.github/workflows/z_local_check-community-approval.yaml
+++ b/.github/workflows/z_local_check-community-approval.yaml
@@ -1,4 +1,4 @@
-name: Check Community Approval
+name: check-community-approval
 on:
   pull_request:
     types:
@@ -10,6 +10,7 @@ on:
 
 jobs:
   check-community-approval:
+    name: check-community-approval
     permissions:
       contents: read
     uses: ./.github/workflows/check-community-approval.yaml

--- a/.github/workflows/z_local_check-community-approval.yaml
+++ b/.github/workflows/z_local_check-community-approval.yaml
@@ -1,0 +1,16 @@
+name: Check Community Approval
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+
+jobs:
+  check-community-approval:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/check-community-approval.yaml
+    secrets: inherit

--- a/.github/workflows/z_local_check-pr-thumbs-up.yaml
+++ b/.github/workflows/z_local_check-pr-thumbs-up.yaml
@@ -1,0 +1,13 @@
+name: Check PR Thumbs Up and Manage Labels
+on:
+  schedule:
+    - cron: '0 5 * * *'   # Runs daily at 10:00 PM MST (5:00 AM UTC next day)
+    - cron: '0 13 * * *'  # Runs daily at 6:00 AM MST (1:00 PM UTC)  
+    - cron: '0 19 * * *'  # Runs daily at 12:00 PM MST (7:00 PM UTC)
+
+jobs:
+  check-pr-thumbs-up:
+    permissions:
+      contents: read
+    uses: ./.github/workflows/check-pr-thumbs-up.yaml
+    secrets: inherit

--- a/.github/workflows/z_local_check-pr-thumbs-up.yaml
+++ b/.github/workflows/z_local_check-pr-thumbs-up.yaml
@@ -1,4 +1,4 @@
-name: Check PR Thumbs Up and Manage Labels
+name: check-pr-thumbs-up
 on:
   schedule:
     - cron: '0 5 * * *'   # Runs daily at 10:00 PM MST (5:00 AM UTC next day)
@@ -7,6 +7,7 @@ on:
 
 jobs:
   check-pr-thumbs-up:
+    name: check-pr-thumbs-up
     permissions:
       contents: read
     uses: ./.github/workflows/check-pr-thumbs-up.yaml

--- a/.github/workflows/z_local_ossf-scorecard.yaml
+++ b/.github/workflows/z_local_ossf-scorecard.yaml
@@ -1,4 +1,4 @@
-name: OSSF Scorecard
+name: ossf-scorecard
 on:
   schedule:
     - cron: '0 5 * * 1' # Every Sunday at 10pm MST (5:00 UTC)
@@ -6,7 +6,8 @@ on:
     branches: [ "main" ]
 
 jobs:
-  analysis:
+  ossf-scorecard:
+    name: ossf-scorecard
     permissions:
       security-events: write
       id-token: write

--- a/.github/workflows/z_local_ossf-scorecard.yaml
+++ b/.github/workflows/z_local_ossf-scorecard.yaml
@@ -1,0 +1,14 @@
+name: OSSF Scorecard
+on:
+  schedule:
+    - cron: '0 5 * * 1' # Every Sunday at 10pm MST (5:00 UTC)
+  push:
+    branches: [ "main" ]
+
+jobs:
+  analysis:
+    permissions:
+      security-events: write
+      id-token: write
+    uses: ./.github/workflows/ossf-scorecard.yaml
+    secrets: inherit

--- a/.github/workflows/z_local_semver-release.yaml
+++ b/.github/workflows/z_local_semver-release.yaml
@@ -1,11 +1,12 @@
-name: Semver Release
+name: semver-release
 on:
   push:
     branches:
       - main
 
 jobs:
-  release:
+  semver-release:
+    name: semver-release
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/z_local_semver-release.yaml
+++ b/.github/workflows/z_local_semver-release.yaml
@@ -1,0 +1,15 @@
+name: Semver Release
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
+    uses: ./.github/workflows/semver-release.yaml
+    secrets: inherit

--- a/.github/workflows/z_local_validate-pr-title.yaml
+++ b/.github/workflows/z_local_validate-pr-title.yaml
@@ -1,4 +1,4 @@
-name: Validate PR Title
+name: validate-pr-title
 on:
   pull_request_target:
     types:
@@ -8,7 +8,8 @@ on:
       - reopened
 
 jobs:
-  validate_pr_title:
+  validate-pr-title:
+    name: validate-pr-title
     permissions:
       pull-requests: read
     uses: ./.github/workflows/validate-pr-title.yaml

--- a/.github/workflows/z_local_validate-pr-title.yaml
+++ b/.github/workflows/z_local_validate-pr-title.yaml
@@ -1,4 +1,4 @@
-name: "Validate PR Title"
+name: Validate PR Title
 on:
   pull_request_target:
     types:

--- a/.github/workflows/z_local_validate-pr-title.yaml
+++ b/.github/workflows/z_local_validate-pr-title.yaml
@@ -1,0 +1,15 @@
+name: "Validate PR Title"
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - edited
+      - reopened
+
+jobs:
+  validate_pr_title:
+    permissions:
+      pull-requests: read
+    uses: ./.github/workflows/validate-pr-title.yaml
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -1,32 +1,35 @@
-# template-repo
+# github-actions-reusable-workflows
 
-[![CodeQL](https://github.com/mindbuttergold/template-repo/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/mindbuttergold/template-repo/actions/workflows/github-code-scanning/codeql) [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/mindbuttergold/template-repo/badge)](https://scorecard.dev/viewer/?uri=github.com/mindbuttergold/template-repo) [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/10740/badge?cache-control=no-cache)](https://www.bestpractices.dev/projects/10740)
+[![CodeQL](https://github.com/mindbuttergold/github-actions-reusable-workflows/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/mindbuttergold/github-actions-reusable-workflows/actions/workflows/github-code-scanning/codeql) [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/mindbuttergold/github-actions-reusable-workflows/badge)](https://scorecard.dev/viewer/?uri=github.com/mindbuttergold/github-actions-reusable-workflows) 
 
-Template repo with foundational config and workflows applicable across all repository setups
+<!-- TODO: Update after first merge -->
+<!-- [!
+[OpenSSF Best Practices](https://www.bestpractices.dev/projects/10740/badge?cache-control=no-cache)](https://www.bestpractices.dev/projects/10740) -->
 
-## Included Components
-
-This template repository provides the following components:
-- README.md
-- Minimal .gitignore
-- MIT OSS License
-- CODEOWNERS
-- renovate.json
-  - Configuration for automated dependency management via Renovate
-- Semantic Release config file and Github Actions workflow
-  - Automatically handles repository releases based on Conventional Commit standards
-- PR title validation Github Actions workflow
-  - Ensures PR title complies with Conventional Commit standards for use with squash merging / semantic release automation
-- Custom PR thumbs up check Github Actions workflow
-  - Checks all open PRs in the repo for thumbs up reactions from at least 5 community members, excluding the PR author
-  - If 5+ thumbs up on PR, automatically adds "community-approved" label to PR
-  - If "community-approved" label was previously added, but thumbs up reduced to below 5, it removes the label
-- Custom community approval label check
-  - Checks if the "community-approved" label is present on the PR
-  - Serves as a required check for PR mergeability
+Centralized repository for reusable Github actions workflows that can be consumed by calling repositories.
 
 ## Usage
 
-Admin / maintainers of the mindbuttergold organization can use this template to create a new repository. The new repository will contain all of the files in this repository.
+Reusable workflows are consumed via a workflow file in the repo where usage is desired, called at the job level.
 
-The only repo-specific changes that need to be made for the new repo are to this README. The badge URLs must be updated, and the openssf best practices self-certification process must be re-conducted for each repo.
+**Note:** The reusable workflow will have only the permissions passed by the consumer repo, so any required permissions must be passed at the caller level. See the individual workflow files in this repo under `./.github/workflows/` for each workflow's required permissions.
+
+**Example Workflow Call:**
+
+```bash
+name: "Validate PR Title"
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - edited
+      - reopened
+
+jobs:
+  validate_pr_title:
+    permissions:
+      pull-requests: read
+    uses: mindbuttergold/github-actions-reusable-workflows/.github/workflows/validate-pr-title.yaml@v1
+    secrets: inherit
+```

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Reusable workflows are consumed via a workflow file in the repo where usage is d
 
 **Note:** The reusable workflow will have only the permissions passed by the consumer repo, so any required permissions must be passed at the caller level. See the individual workflow files in this repo under `./.github/workflows/` for each workflow's required permissions.
 
+Workflows prefixed with `z_local_` are not reusable, they are this repo's local usage.
+
 **Example Workflow Call:**
 
 ```bash


### PR DESCRIPTION
## What is the Feature / Change Being Made?

The template-repo in this org housed Github Actions workflows that were duplicated across each repo. Instead of repeating the common workflows, including semver release, pr title validation, etc, this new repo houses centralized reusable workflows that can be called by other repos instead.

## What is the Rationale in Relation to Best Practices?

This keeps code DRYer, allowing updates to common workflows in this centralized place instead of having to update each repo's workflow individually, can just update the version if / when needed.

## How Has This Been Tested?

Tested each workflow, except semver-release, in [this PR in the template-repo](https://github.com/mindbuttergold/template-repo/pull/8) by pointing to this feature branch. For workflows typically run as cron jobs, I temporarily switched the trigger to on PR. Verified that all workflows are behaving as expected.

## How Can the Community Use This?

Usage instructions are outlined in the README. 

## Links to Related Issues or Discussions

https://github.com/mindbuttergold/aws-multi-account/pull/1#discussion_r2148665328 @BA-CalderonMorales brought up discussion on a previous PR in an org repo about reusability of workflows.

### Contribution Reminders

Your PR needs:
- At least 5 thumbs up from members of the community to be approved / merged
- Final review / approval from at least one maintainer
- Clear, complete, and fully usable code for real-world systems
- No placeholder, unfinished, or copied code with incompatible licensing
- No redundant comments or unrelated artifacts
- The PR title to follow conventional commit standards

Refer the CONTRIBUTING guidelines and CODE_OF_CONDUCT for more information.
